### PR TITLE
Fix docs title

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,7 @@ format = Documenter.HTML(
 
 Documenter.makedocs(;
     plugins = [bib],
-    sitename = "ClimaCore.jl",
+    sitename = "ClimaInterpolations.jl",
     format = format,
     checkdocs = :exports,
     clean = true,


### PR DESCRIPTION
Looks like the repo was just missing public/private keys for Documenter.