### PR TITLE
Add broadcasting wrappers for 1-D interpolation.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,13 +12,13 @@ import ClimaInterpolations.Interpolation1D:
     Linear, interpolate1d!, Flat
 
 FT, DA = Float32, Array
-xmin, xmax, nsource, ntarget = FT(0), FT(2π), 150, 200
-xmintarg, xmaxtarg = xmin, xmax
+xminsource, xmaxsource, nsource, ntarget = FT(0), FT(2π), 150, 200
+xmintarget, xmaxtarget = xminsource, xmaxsource
 
-xsource = DA{FT}(range(xmin, xmax, length = nsource))
-xtarget = DA{FT}(range(xmintarg, xmaxtarg, length = ntarget))
+xsource = DA{FT}(range(xminsource, xmaxsource, length = nsource))
+xtarget = DA{FT}(range(xmintarget, xmaxtarget, length = ntarget))
 
-fsource = sin.(xsource) # function defined on source grid
+fsource = DA(sin.(xsource)) # function defined on source grid
 ftarget = DA(zeros(FT, ntarget)) # allocated function on target grid
 interpolate1d!(ftarget, xsource, xtarget, fsource, Linear(), Flat())
 ```
@@ -30,11 +30,11 @@ import ClimaInterpolations.Interpolation1D:
     Linear, interpolate1d!, Flat
 
 FT, DA = Float32, Array
-xmin, xmax, nsource, ntarget, nlat, nlon = FT(0), FT(2π), 150, 200, 1280, 640
-xmintarg, xmaxtarg = xmin, xmax
+xminsource, xmaxsource, nsource, ntarget, nlat, nlon = FT(0), FT(2π), 150, 200, 1280, 640
+xmintarget, xmaxtarget = xminsource, xmaxsource
 
-xsource = DA{FT}(range(xmin, xmax, length = nsource))
-xtarget = DA{FT}(range(xmintarg, xmaxtarg, length = ntarget))
+xsource = DA{FT}(range(xminsource, xmaxsource, length = nsource))
+xtarget = DA{FT}(range(xmintarget, xmaxtarget, length = ntarget))
 
 xsourcecols = DA(repeat(xsource, 1, nlon, nlat))
 xtargetcols = DA(repeat(xtarget, 1, nlon, nlat))
@@ -45,6 +45,30 @@ interpolate1d!(ftargetcols, xsourcecols, xtargetcols, fsourcecols, Linear(), Fla
 ```
 
 The above examples can be run on NVIDIA GPUs by setting `DA = CuArray`.
+
+1D interpolation can also be invoked using a broadcasting call.
+
+```julia
+import ClimaInterpolations.Interpolation1D:
+    Linear, Interpolate1D, interpolate1d!, Flat
+
+FT, DA = Float32, Array
+xminsource, xmaxsource, nsource, ntarget = FT(0), FT(2π), 150, 200
+xmintarget, xmaxtarget = xminsource, xmaxsource
+
+xsource = DA{FT}(range(xminsource, xmaxsource, length = nsource))
+xtarget = DA{FT}(range(xmintarget, xmaxtarget, length = ntarget))
+
+fsource = DA(sin.(xsource)) # function defined on source grid
+
+itp = Interpolate1D(
+        xsource,
+        fsource,
+        interpolationorder = Linear(),
+        extrapolationorder = Flat(),
+    )
+ftarget = itp.(xtarget)
+```
 
 ## BilinearInterpolation
 `interpolatebilinear!` function can be used to perform bilinear interpolation on a single level on or a multiple horizontal levels of a rectangular grid. Both single threaded CPU and NVIDIA GPU platforms are supported. Examples for single level and multiple level cases are presented below.
@@ -63,17 +87,17 @@ import ClimaInterpolations.Interpolation1D:
 
 FT, DA = Float32, Array
 
-xmin, xmax, nsourcex, ntargetx = FT(0), FT(3π), 2560, 1280
-xmintarg, xmaxtarg = xmin, xmax
+xminsource, xmaxsource, nsourcex, ntargetx = FT(0), FT(3π), 2560, 1280
+xmintarget, xmaxtarget = xminsource, xmaxsource
 
 ymin, ymax, nsourcey, ntargety = FT(0), FT(2π), 2400, 1200
-ymintarg, ymaxtarg = ymin, ymax
+ymintarget, ymaxtarget = ymin, ymax
 
-xsource = DA{FT}(range(xmin, xmax, length = nsourcex))
-xtarget = DA{FT}(range(xmintarg, xmaxtarg, length = ntargetx))
+xsource = DA{FT}(range(xminsource, xmaxsource, length = nsourcex))
+xtarget = DA{FT}(range(xmintarget, xmaxtarget, length = ntargetx))
 
 ysource = DA{FT}(range(ymin, ymax, length = nsourcey))
-ytarget = DA{FT}(range(ymintarg, ymaxtarg, length = ntargety))
+ytarget = DA{FT}(range(ymintarget, ymaxtarget, length = ntargety))
 
 sourcemesh = (
     x = DA([xsource[i] for i in 1:nsourcex, j in 1:nsourcey]),
@@ -102,19 +126,19 @@ import ClimaInterpolations.Interpolation1D:
 
 FT, DA = Float32, Array
 
-xmin, xmax, nsourcex, ntargetx = FT(0), FT(3π), 2560, 1280
-xmintarg, xmaxtarg = xmin, xmax
+xminsource, xmaxsource, nsourcex, ntargetx = FT(0), FT(3π), 2560, 1280
+xmintarget, xmaxtarget = xminsource, xmaxsource
 
 ymin, ymax, nsourcey, ntargety = FT(0), FT(2π), 2400, 1200
-ymintarg, ymaxtarg = ymin, ymax
+ymintarget, ymaxtarget = ymin, ymax
 
 zmin, zmax, nlevels = FT(0), FT(1), 128
 
-xsource = DA{FT}(range(xmin, xmax, length = nsourcex))
-xtarget = DA{FT}(range(xmintarg, xmaxtarg, length = ntargetx))
+xsource = DA{FT}(range(xminsource, xmaxsource, length = nsourcex))
+xtarget = DA{FT}(range(xmintarget, xmaxtarget, length = ntargetx))
 
 ysource = DA{FT}(range(ymin, ymax, length = nsourcey))
-ytarget = DA{FT}(range(ymintarg, ymaxtarg, length = ntargety))
+ytarget = DA{FT}(range(ymintarget, ymaxtarget, length = ntargety))
 
 z = DA{FT}(range(zmin, zmax, length = nlevels))
 

--- a/ext/ClimaInterpolationsCUDAExt.jl
+++ b/ext/ClimaInterpolationsCUDAExt.jl
@@ -6,6 +6,7 @@ import ClimaInterpolations
 import ClimaInterpolations.Interpolation1D:
     interpolate,
     interpolate1d!,
+    Interpolate1D,
     Order1D,
     Extrapolate1D,
     Linear,

--- a/ext/cuda/interpolation1d.jl
+++ b/ext/cuda/interpolation1d.jl
@@ -78,3 +78,5 @@ function interpolate1d_kernel!(
     end
     return nothing
 end
+
+CUDA.Adapt.@adapt_structure Interpolate1D

--- a/test/interpolation1D.jl
+++ b/test/interpolation1D.jl
@@ -1,5 +1,5 @@
 import ClimaInterpolations.Interpolation1D:
-    Linear, interpolate1d!, Flat, LinearExtrapolation
+    Linear, interpolate1d!, Interpolate1D, Flat, LinearExtrapolation
 
 include("utils.jl")
 
@@ -17,7 +17,6 @@ function test_single_column(
     trial_data = nothing
     @testset "1D linear interpolation on single column with $FT" begin
         toler = FT(0.003)
-        order = Linear()
         xsource, xtarget = get_uniform_column_grids(
             DA,
             FT,
@@ -30,7 +29,63 @@ function test_single_column(
         )
         fsource = sin.(xsource) # function defined on source grid
         ftarget = DA(zeros(FT, ntarget)) # allocated function on target grid
-        interpolate1d!(ftarget, xsource, xtarget, fsource, order, extrapolation)
+        interpolate1d!(
+            ftarget,
+            xsource,
+            xtarget,
+            fsource,
+            Linear(),
+            extrapolation,
+        )
+        diff = maximum(
+            abs.(ftarget .- sin.(xtarget)) .* (xtarget .≤ xmax) .*
+            (xtarget .≥ xmin),
+        )
+        @test diff ≤ toler
+        converttoarray = !(DA <: Array)
+        xtarget = converttoarray ? Array(xtarget) : xtarget
+        ftarget = converttoarray ? Array(ftarget) : ftarget
+        fsource = converttoarray ? Array(fsource) : fsource
+        # test extrapolation
+        if xmintarg < xmin || xmaxtarg > xmax
+            if extrapolation == Flat()
+                left_boundary_pass = true
+                right_boundary_pass = true
+                for i in 1:length(xtarget)
+                    if xtarget[i] < xmin
+                        left_boundary_pass = ftarget[i] == fsource[1]
+                    end
+                    if xtarget[i] > xmax
+                        right_boundary_pass = ftarget[i] == fsource[end]
+                    end
+                end
+                @testset "testing Flat extrapolation" begin
+                    @test left_boundary_pass
+                    @test right_boundary_pass
+                end
+            end
+        end
+    end
+    @testset "1D linear interpolation, with broadcasting, on single column with $FT" begin
+        toler = FT(0.003)
+        xsource, xtarget = get_uniform_column_grids(
+            DA,
+            FT,
+            xmin,
+            xmax,
+            xmintarg,
+            xmaxtarg,
+            nsource,
+            ntarget,
+        )
+        fsource = DA(sin.(xsource)) # function defined on source grid
+        itp = Interpolate1D(
+            xsource,
+            fsource,
+            interpolationorder = Linear(),
+            extrapolationorder = extrapolation,
+        )
+        ftarget = itp.(xtarget)
         diff = maximum(
             abs.(ftarget .- sin.(xtarget)) .* (xtarget .≤ xmax) .*
             (xtarget .≥ xmin),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add broadcasting wrappers for 1-D interpolation.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
