### PR TITLE
Add flexibility to 1D interpolation.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,7 +41,17 @@ xtargetcols = DA(repeat(xtarget, 1, nlon, nlat))
 fsourcecols = DA(sin.(xsourcecols))
 ftargetcols = DA(zeros(FT, ntarget, nlon, nlat))
 
+# interpolate with different source grid and target grids for all columns
 interpolate1d!(ftargetcols, xsourcecols, xtargetcols, fsourcecols, Linear(), Flat())
+
+# interpolate with same source and target grids for all columns
+interpolate1d!(ftargetcols, xsource, xtarget, fsourcecols, Linear(), Flat())
+
+# interpolate with same source grid but different target grids for all columns
+interpolate1d!(ftargetcols, xsource, xtargetcols, fsourcecols, Linear(), Flat())
+
+# interpolate with same target grid but different source grids for all columns
+interpolate1d!(ftargetcols, xsourcecols, xtarget, fsourcecols, Linear(), Flat())
 ```
 
 The above examples can be run on NVIDIA GPUs by setting `DA = CuArray`.


### PR DESCRIPTION


<!--- THESE LINES ARE COMMENTED -->
## Purpose 
 This provides the flexibility for the user to use the same source grid for all source columns.
 Similarly, same target grid can be used for all target columns.
 A combination of the above two options are also supported.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
