### PR TITLE
Enable `in-place` 1D interpolation on reversed grids.

### DIFF
--- a/docs/src/Interpolation1D.md
+++ b/docs/src/Interpolation1D.md
@@ -6,6 +6,8 @@ CurrentModule = ClimaInterpolations.Interpolation1D
 
 ```@docs
 interpolate1d!
+interpolate_column!
+Interpolate1D
 get_stencil
 Order1D
 Extrapolate1D

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,6 +23,28 @@ ftarget = DA(zeros(FT, ntarget)) # allocated function on target grid
 interpolate1d!(ftarget, xsource, xtarget, fsource, Linear(), Flat())
 ```
 
+In-place interpolation is also supported on reverse (monotonically decreasing grids).
+Please note that both the source and target grids need to be either monotonically
+increasing (default, `reverse=false`) or monotonically decreasing (reverse=true).
+
+```julia
+# In-place interpolation on a reversed grid
+
+import ClimaInterpolations.Interpolation1D:
+    Linear, interpolate1d!, Flat
+
+FT, DA = Float32, Array
+xminsource, xmaxsource, nsource, ntarget = FT(0), FT(2π), 150, 200
+xmintarget, xmaxtarget = xminsource, xmaxsource
+
+xsource = DA{FT}(reverse(range(xminsource, xmaxsource, length = nsource)))
+xtarget = DA{FT}(reverse(range(xmintarget, xmaxtarget, length = ntarget)))
+
+fsource = DA(sin.(xsource)) # function defined on source grid
+ftarget = DA(zeros(FT, ntarget)) # allocated function on target grid
+interpolate1d!(ftarget, xsource, xtarget, fsource, Linear(), Flat(), reverse = true)
+```
+
 Example for interpolating multiple columns on a CPU:
 
 ```julia

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,34 +10,42 @@ using Aqua
     include("interpolation1D.jl")
 
     for FT in (Float32, Float64)
-        # single column linear interpolation tests without extrapolation
-        test_single_column(Array, FT, get_dims_singlecol(FT)...)
-
-        # single column linear interpolation tests with Flat extrapolation
-        xmin, xmax, nsource, ntarget = get_dims_singlecol(FT)
-        test_single_column(
-            Array,
-            FT,
-            xmin,
-            xmax,
-            nsource,
-            ntarget,
-            xmintarg = xmin - 1.0,
-            xmaxtarg = xmax + 1.0,
-            extrapolation = Flat(),
-        )
-        # multi-column linear interpolation tests without extrapolation
-        xmin, xmax, nsource, ntarget, nlon, nlat = get_dims_multicol(FT)
-        test_multiple_columns(
-            Array,
-            FT,
-            xmin,
-            xmax,
-            nsource,
-            ntarget,
-            nlon,
-            nlat,
-        )
+        for reverse in (false, true)
+            # single column linear interpolation tests without extrapolation
+            test_single_column(
+                Array,
+                FT,
+                get_dims_singlecol(FT)...,
+                reverse = reverse,
+            )
+            # single column linear interpolation tests with Flat extrapolation
+            xmin, xmax, nsource, ntarget = get_dims_singlecol(FT)
+            test_single_column(
+                Array,
+                FT,
+                xmin,
+                xmax,
+                nsource,
+                ntarget,
+                xmintarget = xmin - 1.0,
+                xmaxtarget = xmax + 1.0,
+                extrapolation = Flat(),
+                reverse = reverse,
+            )
+            # multi-column linear interpolation tests without extrapolation
+            xmin, xmax, nsource, ntarget, nlon, nlat = get_dims_multicol(FT)
+            test_multiple_columns(
+                Array,
+                FT,
+                xmin,
+                xmax,
+                nsource,
+                ntarget,
+                nlon,
+                nlat,
+                reverse = reverse,
+            )
+        end
     end
 end
 

--- a/test/runtests_cuda.jl
+++ b/test/runtests_cuda.jl
@@ -9,34 +9,42 @@ using ClimaInterpolations
     include("interpolation1D.jl")
 
     for FT in (Float32, Float64)
-        # single column linear interpolation tests without extrapolation
-        test_single_column(CuArray, FT, get_dims_singlecol(FT)...)
-
-        # single column linear interpolation tests with Flat extrapolation
-        xmin, xmax, nsource, ntarget = get_dims_singlecol(FT)
-        test_single_column(
-            CuArray,
-            FT,
-            xmin,
-            xmax,
-            nsource,
-            ntarget,
-            xmintarg = xmin - 1.0,
-            xmaxtarg = xmax + 1.0,
-            extrapolation = Flat(),
-        )
-        # multi-column linear interpolation tests without extrapolation
-        xmin, xmax, nsource, ntarget, nlon, nlat = get_dims_multicol(FT)
-        test_multiple_columns(
-            CuArray,
-            FT,
-            xmin,
-            xmax,
-            nsource,
-            ntarget,
-            nlon,
-            nlat,
-        )
+        for reverse in (false, true)
+            # single column linear interpolation tests without extrapolation
+            test_single_column(
+                CuArray,
+                FT,
+                get_dims_singlecol(FT)...,
+                reverse = reverse,
+            )
+            # single column linear interpolation tests with Flat extrapolation
+            xmin, xmax, nsource, ntarget = get_dims_singlecol(FT)
+            test_single_column(
+                CuArray,
+                FT,
+                xmin,
+                xmax,
+                nsource,
+                ntarget,
+                xmintarget = xmin - 1.0,
+                xmaxtarget = xmax + 1.0,
+                extrapolation = Flat(),
+                reverse = reverse,
+            )
+            # multi-column linear interpolation tests without extrapolation
+            xmin, xmax, nsource, ntarget, nlon, nlat = get_dims_multicol(FT)
+            test_multiple_columns(
+                CuArray,
+                FT,
+                xmin,
+                xmax,
+                nsource,
+                ntarget,
+                nlon,
+                nlat,
+                reverse = reverse,
+            )
+        end
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,15 +1,55 @@
-function get_uniform_column_grids(
+get_uniform_column_grids(
     ::Type{DA},
     ::Type{FT},
-    xmin,
-    xmax,
-    xmintarg,
-    xmaxtarg,
+    xminsource,
+    xmaxsource,
+    xmintarget,
+    xmaxtarget,
     nsource,
     ntarget,
-) where {DA, FT}
-    return (
-        DA{FT}(range(xmin, xmax, length = nsource)),
-        DA{FT}(range(xmintarg, xmaxtarg, length = ntarget)),
+    reverse = false,
+) where {DA, FT} =
+    reverse ?
+    (
+        DA{FT}(range(xmaxsource, xminsource, length = nsource)),
+        DA{FT}(range(xmaxtarget, xmintarget, length = ntarget)),
+    ) :
+    (
+        DA{FT}(range(xminsource, xmaxsource, length = nsource)),
+        DA{FT}(range(xmintarget, xmaxtarget, length = ntarget)),
     )
+
+function test_extrapolation(
+    (xminsource, xmaxsource),
+    (xmintarget, xmaxtarget),
+    xtarget,
+    fsource,
+    ftarget,
+    extrapolation,
+    reverse = false,
+)
+    if xmintarget < xminsource || xmaxtarget > xmaxsource
+        xtargetcpu = typeof(xtarget) <: Array ? xtarget : Array(xtarget)
+        fsourcecpu = typeof(fsource) <: Array ? fsource : Array(fsource)
+        ftargetcpu = typeof(ftarget) <: Array ? ftarget : Array(ftarget)
+        if extrapolation == Flat()
+            left_boundary_pass = true
+            right_boundary_pass = true
+            fsourceleft = reverse ? fsourcecpu[end] : fsourcecpu[1]
+            fsourceright = reverse ? fsourcecpu[1] : fsourcecpu[end]
+            for i in 1:length(xtargetcpu)
+                if xtargetcpu[i] < xminsource
+                    left_boundary_pass = ftargetcpu[i] == fsourceleft
+                end
+                if xtargetcpu[i] > xmaxsource
+                    right_boundary_pass = ftargetcpu[i] == fsourceright
+                end
+            end
+            @testset "testing Flat extrapolation" begin
+                @test left_boundary_pass
+                @test right_boundary_pass
+            end
+        end
+    end
+    return nothing
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Enable `in-place` 1D interpolation on reversed grids. This is particularly useful for interpolation on pressure grids.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
