### PR TITLE
Relax compat for DocStringExtensions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: new-central
+  queue: central
   slurm_mem: 8G
   modules: climacommon/2024_12_16
 

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ClimaInterpolationsCUDAExt = "CUDA"
 
 [compat]
-Aqua = "0.8.5"
+Aqua = "0.8"
 CUDA = "5.5"
 DocStringExtensions = "=0.5, 0.5 - 0.9"
 SafeTestsets = "0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaInterpolations"
 uuid = "dd0f122e-fa3b-47f3-bcf0-93bbc60d885e"
 authors = ["Climate Modeling Alliance"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ ClimaInterpolationsCUDAExt = "CUDA"
 [compat]
 Aqua = "0.8.5"
 CUDA = "5.5"
-DocStringExtensions = "0.9"
+DocStringExtensions = "=0.5, 0.5 - 0.9"
 SafeTestsets = "0.1"
 Test = "1"
 julia = "1.9"


### PR DESCRIPTION
closes #21 - This PR relaxes the compat for DocStringExtensions and release a new version. This is causing a problem for the Downgrade test in ClimaCore (see https://github.com/CliMA/ClimaCore.jl/pull/2422). 